### PR TITLE
Feature/US-56

### DIFF
--- a/OngProject/Controllers/NewsController.cs
+++ b/OngProject/Controllers/NewsController.cs
@@ -62,8 +62,22 @@ namespace OngProject.Controllers
 
         // DELETE api/<NewsController>/5
         [HttpDelete("{id}")]
-        public void Delete(int id)
+        [Authorize(Roles = "Administrator")]
+        public async Task<IActionResult> Delete(int id)
         {
+            try
+            {
+                var result = await this._newsService.Delete(id);
+                if (result.Success)
+                {
+                    return Ok(result);
+                }
+                return BadRequest(result);
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
         }
     }
 }

--- a/OngProject/Core/Business/NewsService.cs
+++ b/OngProject/Core/Business/NewsService.cs
@@ -68,9 +68,29 @@ namespace OngProject.Core.Business
         {
             throw new NotImplementedException();
         }
-        public async Task<Result> Delete(New news)
+        public async Task<Result> Delete(int id)
         {
-            throw new NotImplementedException();
+            try
+            {
+                var newEntity = await this._unitOfWork.NewsRepository.GetByIdAsync(id);
+                if (newEntity != null)
+                {
+                    if (newEntity.SoftDelete)
+                    {
+                        return Result.FailureResult($"id({newEntity.Id}) ya esta eliminado del sistema.");
+                    }
+                    newEntity.SoftDelete = true;
+                    newEntity.LastModified = DateTime.Today;
+                    await this._unitOfWork.SaveChangesAsync();
+
+                    return Result<string>.SuccessResult($"Noticia:({newEntity.Id}) ha sido eliminada exitosamente.");
+                }
+                return Result.FailureResult("id de noticia inexistente.");
+            }
+            catch (Exception e)
+            {
+                return Result.ErrorResult(new List<string> { e.Message });
+            }
         }
     }
 }

--- a/OngProject/Core/Interfaces/INewsService.cs
+++ b/OngProject/Core/Interfaces/INewsService.cs
@@ -12,6 +12,6 @@ namespace OngProject.Core.Interfaces
         New GetById();
         Task<Result> Insert(NewDtoForUpload newDTO);
         Task<Result> Update(New news);
-        Task<Result> Delete(New news);
+        Task<Result> Delete(int id);
     }
 }


### PR DESCRIPTION
Changelog:
*Endpoint delete for news has been implemented following the US-56

Case succesful delete:
![image](https://user-images.githubusercontent.com/64286501/153018766-90c573bc-325d-4dbb-be65-576aa1183c7f.png)
![image](https://user-images.githubusercontent.com/64286501/153018782-1935c451-c1f7-4603-8241-17bb7d1091a0.png)
![image](https://user-images.githubusercontent.com/64286501/153018800-abcc7830-77e8-4a1a-94be-9516e1ef5f93.png)
![image](https://user-images.githubusercontent.com/64286501/153018821-e0ca0642-9ce1-4629-a027-699cedd21a98.png)
The delete is logical.

Case id doesn't exist:
![image](https://user-images.githubusercontent.com/64286501/153018913-fc36723d-8233-4832-a628-f78875749c5e.png)
![image](https://user-images.githubusercontent.com/64286501/153018938-5871e7f9-c924-4ee0-8fc0-0f248f5ef825.png)


